### PR TITLE
support jmix 2.7

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -19,7 +19,7 @@ buildscript {
         gradlePluginPortal()
     }
     dependencies {
-        classpath "io.jmix.gradle:jmix-gradle-plugin:2.3.0"
+        classpath 'io.jmix.gradle:jmix-gradle-plugin:2.7.1'
     }
 }
 
@@ -38,7 +38,7 @@ subprojects {
     }
 
     jmix {
-        bomVersion = '2.3.0'
+        bomVersion = '2.7.1'
         projectId = 'locstr'
     }
 
@@ -46,17 +46,12 @@ subprojects {
     version = this.version
 
     if (it.name != 'jmix-localized-string-datatype-demo') {
-        def props = new Properties()
-        buildFile.withInputStream { props.load(it) }
-        def subArchivesBaseName = props.getProperty('archivesBaseName')
-        def archName = subArchivesBaseName.substring(1, subArchivesBaseName.length() - 1)
-
         java {
             withSourcesJar()
         }
 
         artifacts {
-            archives sourcesJar
+            archives(sourcesJar)
         }
 
         publishing {
@@ -72,7 +67,7 @@ subprojects {
             }
             publications {
                 javaMaven(MavenPublication) {
-                    artifactId = archName
+                    artifactId = project.name
                     from components.java
                 }
             }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.7-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.12.1-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/jmix-localized-string-datatype-demo/jmix-localized-string-datatype-demo.gradle
+++ b/jmix-localized-string-datatype-demo/jmix-localized-string-datatype-demo.gradle
@@ -19,10 +19,8 @@ apply plugin: 'io.jmix'
 apply plugin: 'org.springframework.boot'
 apply plugin: 'com.vaadin'
 
-archivesBaseName = 'jmix-localized-string-datatype-demo'
-
 jmix {
-    bomVersion = '2.3.1'
+    bomVersion = '2.7.1'
 }
 
 dependencies {

--- a/jmix-localized-string-datatype-starter/jmix-localized-string-datatype-starter.gradle
+++ b/jmix-localized-string-datatype-starter/jmix-localized-string-datatype-starter.gradle
@@ -14,8 +14,6 @@
  * limitations under the License.
  */
 
-archivesBaseName = 'jmix-localized-string-datatype-starter'
-
 jmix {
     entitiesEnhancing {
         enabled = false

--- a/jmix-localized-string-datatype/gradle.properties
+++ b/jmix-localized-string-datatype/gradle.properties
@@ -1,5 +1,5 @@
 #
-# Copyright 2024 Gleb Gorelov.
+# Copyright 2025 Gleb Gorelov.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -14,7 +14,4 @@
 # limitations under the License.
 #
 
-jmix.core.available-locales=en
-jmix.ui.component.default-trim-enabled=false
-jmix.gridexport.default-columns-to-export=ALL_COLUMNS
-jmix.ui.view-file-extensions=htm, html, jpg, png, jpeg, pdf
+hilla.active=false

--- a/jmix-localized-string-datatype/jmix-localized-string-datatype.gradle
+++ b/jmix-localized-string-datatype/jmix-localized-string-datatype.gradle
@@ -14,8 +14,6 @@
  * limitations under the License.
  */
 
-archivesBaseName = 'jmix-localized-string-datatype'
-
 dependencies {
     implementation 'io.jmix.core:jmix-core-starter'
     implementation 'io.jmix.data:jmix-eclipselink-starter'
@@ -26,8 +24,14 @@ dependencies {
         exclude group: 'org.junit.vintage', module: 'junit-vintage-engine'
     }
     testImplementation 'org.springframework.boot:spring-boot-starter-web'
+    testImplementation 'org.junit.platform:junit-platform-launcher'
 
     testRuntimeOnly 'org.hsqldb:hsqldb'
+}
+
+configurations.implementation {
+    exclude group: 'com.vaadin', module: 'hilla'
+    exclude group: 'com.vaadin', module: 'hilla-dev'
 }
 
 test {


### PR DESCRIPTION
- Update Gradle build scripts to resolve deprecation warnings for archivesBaseName and space-assignment syntax.
- Refactor the root build script to remove fragile file parsing and use the project name for the Maven artifact ID, fixing a subsequent build failure.
- Resolve a JUnit 5 test execution failure by explicitly adding a dependency on junit-platform-launcher to ensure consistent library versions.